### PR TITLE
Make Firefox addon usable with unpack=false

### DIFF
--- a/src/components/https-everywhere.js
+++ b/src/components/https-everywhere.js
@@ -92,7 +92,7 @@ const WHERE_UNTRUSTED = 1;
 const WHERE_TRUSTED = 2;
 const ANYWHERE = 3;
 
-const N_COHORTS = 1000; 
+const N_COHORTS = 1000;
 
 const DUMMY_OBJ = {};
 DUMMY_OBJ.wrappedJSObject = DUMMY_OBJ;
@@ -146,7 +146,7 @@ function HTTPSEverywhere() {
   // we rewrite.
   this.obsService = CC["@mozilla.org/observer-service;1"]
                     .getService(Components.interfaces.nsIObserverService);
-                    
+
   if (this.prefs.getBoolPref("globalEnabled")) {
     this.obsService.addObserver(this, "profile-before-change", false);
     this.obsService.addObserver(this, "profile-after-change", false);
@@ -180,10 +180,10 @@ In recent versions of Firefox and HTTPS Everywhere, the call stack for performin
 1. HTTPSEverywhere.shouldIgnoreURI() checks for very quick reasons to ignore a
 request, such as redirection loops, non-HTTP[S] URIs, and OCSP
 
-    2. HTTPS.replaceChannel() 
+    2. HTTPS.replaceChannel()
 
-       3. HTTPSRules.rewrittenURI() 
-            
+       3. HTTPSRules.rewrittenURI()
+
            4. HTTPSRules.potentiallyApplicableRulesets uses <target host=""> elements to identify relevant rulesets
 
            foreach RuleSet:
@@ -469,9 +469,7 @@ HTTPSEverywhere.prototype = {
   loadOCSPList: function() {
     try {
       var loc = "chrome://https-everywhere/content/code/commonOCSP.json";
-      var file = CC["@mozilla.org/file/local;1"].createInstance(CI.nsILocalFile);
-      file.initWithPath(this.rw.chromeToPath(loc));
-      var data = this.rw.read(file);
+      var data = this.rw.readFromUrl(loc);
       this.ocspList = JSON.parse(data);
     } catch(e) {
       this.log(WARN, "Failed to load OCSP list: " + e);
@@ -632,7 +630,7 @@ HTTPSEverywhere.prototype = {
     // This variable is used for gradually turning on features for testing and
     // scalability purposes.  It is a random integer [0,N_COHORTS) generated
     // once and stored thereafter.
-    // 
+    //
     // This is not currently used/called in the development branch
     var cohort;
     try {
@@ -646,7 +644,7 @@ HTTPSEverywhere.prototype = {
 
   // nsIChannelEventSink implementation
   // XXX This was here for rewrites in the past.  Do we still need it?
-  onChannelRedirect: function(oldChannel, newChannel, flags) {  
+  onChannelRedirect: function(oldChannel, newChannel, flags) {
     const uri = newChannel.URI;
     this.log(DBUG,"Got onChannelRedirect to "+uri.spec);
     if (!(newChannel instanceof CI.nsIHttpChannel)) {
@@ -663,7 +661,7 @@ HTTPSEverywhere.prototype = {
     // secure the load process was for this page
     var browser = this.getBrowserForChannel(oldChannel);
     var old_alist = null;
-    if (browser) 
+    if (browser)
       old_alist = this.getExpando(browser,"applicable_rules");
     browser = this.getBrowserForChannel(newChannel);
     if (!browser) return null;
@@ -739,18 +737,18 @@ HTTPSEverywhere.prototype = {
   },
 
   chrome_opener: function(uri, args) {
-    // we don't use window.open, because we need to work around TorButton's 
+    // we don't use window.open, because we need to work around TorButton's
     // state control
     args = args || 'chrome,centerscreen';
     return CC['@mozilla.org/appshell/window-mediator;1']
-      .getService(CI.nsIWindowMediator) 
+      .getService(CI.nsIWindowMediator)
       .getMostRecentWindow('navigator:browser')
       .open(uri,'', args );
   },
 
   tab_opener: function(uri) {
     var gb = CC['@mozilla.org/appshell/window-mediator;1']
-      .getService(CI.nsIWindowMediator) 
+      .getService(CI.nsIWindowMediator)
       .getMostRecentWindow('navigator:browser')
       .gBrowser;
     var tab = gb.addTab(uri);
@@ -844,7 +842,7 @@ function https_everywhereLog(level, str) {
     prefs = HTTPSEverywhere.instance.get_prefs();
     econsole = Components.classes["@mozilla.org/consoleservice;1"]
                .getService(Components.interfaces.nsIConsoleService);
-  } 
+  }
   try {
     var threshold = prefs.getIntPref(LLVAR);
   } catch (e) {

--- a/src/install.rdf
+++ b/src/install.rdf
@@ -13,7 +13,7 @@
         <em:multiprocessCompatible>true</em:multiprocessCompatible>
         <em:homepageURL>https://www.eff.org/https-everywhere</em:homepageURL>
         <em:iconURL>chrome://https-everywhere/skin/https-everywhere.png</em:iconURL>
-        <em:unpack>true</em:unpack> <!-- Required for Firefox 4 -->
+        <em:unpack>false</em:unpack> <!-- Required for Firefox 4 -->
         <em:updateURL>https://www.eff.org/files/https-everywhere-eff-update-2048.rdf</em:updateURL> <!-- 2015-08-14: New update URL to go with new id (https-everywhere-eff@ef.org) -->
         <em:updateKey>MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA6MR8W/galdxnpGqBsYbqOzQb2eyW15YFjDDEMI0ZOzt8f504obNs920lDnpPD2/KqgsfjOgw2K7xWDJIj/18xUvWPk3LDkrnokNiRkA3KOx3W6fHycKL+zID7zy+xZYBuh2fLyQtWV1VGQ45iNRp9+Zo7rH86cdfgkdnWTlNSHyTLW9NbXvyv/E12bppPcEvgCTAQXgnDVJ0/sqmeiijn9tTFh03aM+R2V/21h8aTraAS24qiPCz6gkmYGC8yr6mglcnNoYbsLNYZ69zF1XHcXPduCPdPdfLlzVlKK1/U7hkA28eG3BIAMh6uJYBRJTpiGgaGdPd7YekUB8S6cy+CQIDAQAB</em:updateKey>
         <!-- Firefox -->
@@ -35,11 +35,11 @@
         <!-- thunderbird -->
         <em:targetApplication>
             <Description>
-                <em:id>{3550f703-e582-4d05-9a08-453d09bdfdc6}</em:id> 
+                <em:id>{3550f703-e582-4d05-9a08-453d09bdfdc6}</em:id>
                 <em:minVersion>17.*</em:minVersion>
                 <em:maxVersion>35.*</em:maxVersion>
-            </Description> 
-        </em:targetApplication> 
+            </Description>
+        </em:targetApplication>
         <!-- Conkeror -->
         <em:targetApplication>
           <Description>


### PR DESCRIPTION
In order to make https-everywhere a SystemAddon, it cannot have unpack true flag in install.rdf
The flag was there, so ruleset.json can be references with FileUtils API. 

This PR, introduce alternative way of loading rulesets that are exposed as chrome resources. In this way an extension can be marked as unpack=false