### PR TITLE
Fetch rulset via chrome url

### DIFF
--- a/src/chrome/content/code/HTTPSRules.js
+++ b/src/chrome/content/code/HTTPSRules.js
@@ -246,7 +246,30 @@ const RuleWriter = {
     return rv;
   },
 
-  read: function(file) {
+  readFromUrl: function (url) {
+    var ios = CC['@mozilla.org/network/io-service;1']
+        .getService(CI.nsIIOService);
+    var encoding = "UTF-8";
+    var channel = ios.newChannel(url, encoding, null);
+    var stream = channel.open();
+    var streamSize = stream.available();
+
+    if (!streamSize) {
+      return null;
+    }
+
+    var convStream = CC["@mozilla.org/intl/converter-input-stream;1"]
+        .createInstance(CI.nsIConverterInputStream);
+
+    convStream.init(stream, encoding, streamSize,
+        convStream.DEFAULT_REPLACEMENT_CHARACTER);
+
+    var data = {};
+    convStream.readString(streamSize, data);
+
+    return data.value;
+  },
+  readFromFile: function(file) {
     if (!file.exists())
       return null;
     var data = "";
@@ -285,7 +308,7 @@ const RuleWriter = {
   rulesetFromFile: function(file, rule_store, ruleset_id) {
     if ((rule_store.targets == null) && (rule_store.targets != {}))
       this.log(WARN, "TARGETS IS NULL");
-    var data = this.read(file);
+    var data = this.readFromFile(file);
     if (!data) return null;
     return this.readFromString(data, rule_store, ruleset_id);
   },
@@ -409,8 +432,9 @@ const HTTPSRules = {
    * XML string, which will be parsed on an as-needed basis.
    */
   loadTargets: function() {
-    var file = new FileUtils.File(RuleWriter.chromeToPath("chrome://https-everywhere/content/rulesets.json"));
-    var rules = JSON.parse(RuleWriter.read(file));
+    var loc = "chrome://https-everywhere/content/rulesets.json");
+    var data = RuleWriter.readFromUrl(loc);
+    var rules = JSON.parse(data);
     this.targets = rules.targets;
     this.rulesetStrings = rules.rulesetStrings;
   },

--- a/src/components/https-everywhere.js
+++ b/src/components/https-everywhere.js
@@ -469,9 +469,7 @@ HTTPSEverywhere.prototype = {
   loadOCSPList: function() {
     try {
       var loc = "chrome://https-everywhere/content/code/commonOCSP.json";
-      var file = CC["@mozilla.org/file/local;1"].createInstance(CI.nsILocalFile);
-      file.initWithPath(this.rw.chromeToPath(loc));
-      var data = this.rw.read(file);
+      var data = this.rw.readFromFile(loc);
       this.ocspList = JSON.parse(data);
     } catch(e) {
       this.log(WARN, "Failed to load OCSP list: " + e);

--- a/src/install.rdf
+++ b/src/install.rdf
@@ -13,7 +13,7 @@
         <em:multiprocessCompatible>true</em:multiprocessCompatible>
         <em:homepageURL>https://www.eff.org/https-everywhere</em:homepageURL>
         <em:iconURL>chrome://https-everywhere/skin/https-everywhere.png</em:iconURL>
-        <em:unpack>true</em:unpack> <!-- Required for Firefox 4 -->
+        <em:unpack>false</em:unpack> <!-- Required for Firefox 4 -->
         <em:updateURL>https://www.eff.org/files/https-everywhere-eff-update-2048.rdf</em:updateURL> <!-- 2015-08-14: New update URL to go with new id (https-everywhere-eff@ef.org) -->
         <em:updateKey>MIIBIjANBgkqhkiG9w0BAQEFAAOCAQ8AMIIBCgKCAQEA6MR8W/galdxnpGqBsYbqOzQb2eyW15YFjDDEMI0ZOzt8f504obNs920lDnpPD2/KqgsfjOgw2K7xWDJIj/18xUvWPk3LDkrnokNiRkA3KOx3W6fHycKL+zID7zy+xZYBuh2fLyQtWV1VGQ45iNRp9+Zo7rH86cdfgkdnWTlNSHyTLW9NbXvyv/E12bppPcEvgCTAQXgnDVJ0/sqmeiijn9tTFh03aM+R2V/21h8aTraAS24qiPCz6gkmYGC8yr6mglcnNoYbsLNYZ69zF1XHcXPduCPdPdfLlzVlKK1/U7hkA28eG3BIAMh6uJYBRJTpiGgaGdPd7YekUB8S6cy+CQIDAQAB</em:updateKey>
         <!-- Firefox -->


### PR DESCRIPTION
In order to make https-everywhere a SystemAddon, it cannot have unpack true flag in install.rdf. The flag was there, so ruleset.json can be referenceswith FileUtils API.

This PR, introduce alternative way of loading rulesets that are exposed as chrome resources. In this way an extension can be marked as unpack=false